### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is tag for every link it is either Free, Paid or Mixed. <br>
  :moneybag: - Paid   <br>
  :arrows_counterclockwise: - Mixed 
 
-####Coding resources for beginners of all ages 
+#### Coding resources for beginners of all ages 
 
 + <a href="https://code.org/" target="_blank"> Code.org Tutorials </a> Simple tutorials/puzzles for beginners that can be completed in an hour or less. :free:
 + <a href="https://developer.mozilla.org/en-US/"> Mozila Developer Network </a> Shared knowledge for the Open Web. HTML/HTML5, CSS/CSS3, Web APIs & DOM, Javascript, SVG, WEBGL, MathML. :free:
@@ -40,7 +40,7 @@ There is tag for every link it is either Free, Paid or Mixed. <br>
 + <a href="https://codecombat.com/" target="_blank"> CodeCombat </a> An online game that teaches programming. Students write code in real programming languages (Python, JavaScript, Lua, CofeeScript, Clojure). :arrows_counterclockwise:
 + <a href="https://www.hackerearth.com/practice/codemonk/" target="_blank"> Codemonk on Hackerearth </a> An online platform which teaches coding from very basics to higher level where Questions are divided into topics with each topic having tutorial followed by a competition each week and level of difficulty is good for beginners(All languages). :free:
 
-####Coding for younger beginners 
+#### Coding for younger beginners 
 
 + <a href="http://kata.coderdojo.com/wiki/Learning_Resource" target="_blank"> CoderDojo </a> Open source, game based learning resources for young people to learn the fundamentals of coding with fun results! :free:
 + <a href="https://www.robomindacademy.com/" target="_blank"> RoboMind Academy </a>  By programming a virtual robot, the student is introduced to logic, automation and technology. Available as an online educator-friendly platform that can be used with students aged 8 years or older. :free:
@@ -48,7 +48,7 @@ There is tag for every link it is either Free, Paid or Mixed. <br>
 + <a href="https://www.playcodemonkey.com/" target="_blank"> CodeMonkey </a> In this free technology and STEM game, students learn about computer coding concepts like functions and loops by programming a monkey to find bananas! Real world programming language. Write code. Catch bananas. Save the world. :free:
 + <a href="https://blockly-games.appspot.com/" target="_blank"> Blockly </a> Build a simple computer application by programming “tag” blocks to reach your target – no typing required.  :free:
 
-####The Hour of Code
+#### The Hour of Code
 
 + <a href="https://studio.code.org/hoc/1" target="_blank"> Code.org </a> This course introduces the Angry Birds. Coding basics are explained by Mark Zuckerberg and Chris Bosh.  :free:
 + <a href="https://scratch.mit.edu/hoc2014/" target="_blank"> Scratch </a> With Scratch, you can create your own interactive games, stories, animations — and share them with your friends. Get started by animating your name, creating a holiday card, or making a pong game.  :free:
@@ -74,7 +74,7 @@ There is tag for every link it is either Free, Paid or Mixed. <br>
 + <a href="https://www.kodable.com/hour-of-code" target="_blank"> Kodable </a> Kodable is a self-guided iPad game that introduces kids 5+ to programming basics. Having a teacher or parent nearby is optimal, but not necessary. :arrows_counterclockwise:
 + <a href="https://groklearning.com/hoc-2014/" target="_blank"> Grok learning </a> Use the programming language Python to build a chatbot called "Eliza" to act as a robot psychotherapist. You'll teach Eliza how to talk and the right thing to say. Can she fool your friends into thinking she's a human not a computer? :arrows_counterclockwise:
 
-####Beyond an Hour
+#### Beyond an Hour
 
 + <a href="https://www.edx.org/course/introduction-computer-science-harvardx-cs50x/" target="_blank"> Introduction to Computer Science </a> An introduction to the intellectual enterprises of computer science and the art of programming. You will learn concepts like abstraction, algorithms, data structures, encapsulation, resource management, security, software engineering, and web development.  :free:
 + <a href="https://www.coursera.org/course/cs101/" target="_blank"> Computer Science 101 </a> CS101 teaches the essential ideas of Computer Science for a zero-prior-experience audience. The course uses small coding experiments in the browser to play with the nature of computers, understanding their strengths and limitations.  :free:
@@ -82,7 +82,7 @@ There is tag for every link it is either Free, Paid or Mixed. <br>
 + <a href="http://www.teachingtree.co/" target="_blank"> Teaching Tree </a> TeachingTree is an open platform that lets anybody organize educational content.  :free:
 + <a href="https://www.udacity.com/course/cs101" target="_blank"> Intro to Computer Science </a> You’ll learn and practice key computer science concepts by building your own versions of popular web applications. You’ll learn Python, a powerful, easy-to-learn, and widely used programming language, and you’ll explore computer science basics, as you build your own search engine and social network. :moneybag:
 
-####Learn to program with robots
+#### Learn to program with robots
 
 + <a href="http://sparkfun.codepops.com/#0/" target="_blank"> Sparkfun </a> Arduino Unplugged -- Hour of Code with Sparkfun's Digital Sandbox.  :free:
 + <a href="https://tickleapp.com/en-us/" target="_blank"> Tickle </a> Learn to program Arduino, drones, robots, connected toys, and smart home devices, all wirelessly. Tickle is easy to learn, fun to use, and 1000x more powerful!  :arrows_counterclockwise:
@@ -92,7 +92,7 @@ There is tag for every link it is either Free, Paid or Mixed. <br>
 + <a href="http://www.sphero.com/education/" target="_blank"> Sphero </a>  SPRK makes the skills of the future approachable and practical. And most importantly, fun. Learn: Drag and drop C-based block programming, Block programming in your Chrome browser, Programming with visual macros and more! :moneybag:
 + <a href="https://www.makewonder.com/" target="_blank"> Wonder </a> Home of Dash and Dot, robots that you can code. :moneybag:
 
-####Make your own games or apps
+#### Make your own games or apps
 
 + <a href="https://www.makeschool.com/build-an-iphone-game-in-your-browser" target="_blank"> MakeSchool </a> Learn the basics of programming using the Swift programming language. Build an iphone game in your browser.  :free:
 + <a href="https://studio.code.org/flappy/1" target="_blank"> Code.org Flappy Bird</a> Create your custom version of flappy bird using event handlers. The code you'll write involves dragging and dropping blocks.  :free:
@@ -105,7 +105,7 @@ There is tag for every link it is either Free, Paid or Mixed. <br>
 teaches kids to code! :moneybag:
 + <a href="http://twolivesleft.com/Codea/" target="_blank"> Codea </a> Codea for iPad lets you create games and simulations - or just about any visual idea you have. Turn your thoughts into interactive creations that make use of iPad features like Multi-Touch and the accelerometer. :moneybag:
 
-####Apps for phones and tablets
+#### Apps for phones and tablets
 
 + <a href="https://scratch.mit.edu/" target="_blank"> Scratch </a> With Scratch, you can program your own stories, games, and animations — and share them online. :free:
 + <a href="http://www.scratchjr.org/" target="_blank"> ScratchJr </a> With ScratchJr, young children (ages 5-7) can program their own interactive stories and games. In the process, they learn to solve problems, design projects, and express themselves creatively on the computer. :free:
@@ -123,7 +123,7 @@ teaches kids to code! :moneybag:
 + <a href="http://twolivesleft.com/Codea/" target="_blank"> Codea </a> Codea for iPad lets you create games and simulations - or just about any visual idea you have. Turn your thoughts into interactive creations that make use of iPad features like Multi-Touch and the accelerometer. :moneybag:
 + <a href="https://itunes.apple.com/us/app/catos-hike-programming-logic/id574335479?mt=8" target="_blank"> Cato's Hike </a>Cato's Hike: A Programming and Logic Odyssey :moneybag: 
 
-####Courses for advanced learners
+#### Courses for advanced learners
 
 + <a href="https://www.edx.org/course-list/allschools/computer-science/allcourses" target="_blank"> edX </a> Open edX is the open-source platform that powers edX courses and is freely available. With Open edX, educators and technologists can build learning tools and contribute new features to the platform, creating innovative solutions to benefit students everywhere. :free:
 + <a href="http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/" target="_blank"> MIT OpenCourseWare </a> MIT OpenCourseWare makes the materials used in the teaching of almost all of MIT's subjects available on the Web, free of charge. With more than 2,200 courses available, OCW is delivering on the promise of open sharing of knowledge. :free:
@@ -133,19 +133,19 @@ teaches kids to code! :moneybag:
 + <a href="http://www.lynda.com/Developer-training-tutorials/50-0.html/" target="_blank"> Lynda </a> lynda.com is a leading online learning company that helps anyone learn business, software, technology and creative skills to achieve personal and professional goals. :arrows_counterclockwise:
 + <a href="https://laracasts.com/" target="_blank"> Laracasts </a> The best PHP and Laravel screencasts on the web.  :moneybag:
 
-####License
+#### License
 [![CC0](http://i.creativecommons.org/p/mark/1.0/88x31.png)](http://creativecommons.org/publicdomain/mark/1.0/)
 
 To the extent possible under law, [George Gognadze](https://github.com/dreamtocode) has waived all copyright and related or neighboring rights to this work.
 
-####Contributing
+#### Contributing
 All contributions are welcome but please do not create a pull request without reading this guide first. Failure to do so may result in the rejection of the pull request.
 
 + Fork the repository 
 + Make changes to your fork also make sure that your changes are adequate to our repository and you don't provide the same thing that is already included
 + Say why you proposing the changes, and make sure that you add changes at the bottom of the corresponding list and not at the top or in the middle. Click on "Propose file change" with a smile :smile:
 
-####References
+#### References
 
 + <a href="https://www.google.com/about/careers/students/guide-to-technical-development.html" target="_blank"> Google - Guide for Technical Development </a> This guide provides tips and resources to help you develop your technical skills (academically and non-academically) through self-paced, hands-on learning. This guide is intended to target Computer Science students seeking an internship or university grad role at Google. :free:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
